### PR TITLE
Improvements

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -374,9 +374,8 @@ func TestConcurrentCall(t *testing.T) {
 	defer s.Stop()
 
 	c := &Client{
-		Addr:       ":15351",
-		Conns:      2,
-		FlushDelay: time.Millisecond,
+		Addr:  ":15351",
+		Conns: 2,
 	}
 	c.Start()
 	defer c.Stop()
@@ -412,7 +411,6 @@ func TestCompress(t *testing.T) {
 	c1 := &Client{
 		Addr:               ":15352",
 		Conns:              2,
-		FlushDelay:         time.Millisecond,
 		DisableCompression: true,
 	}
 	c1.Start()
@@ -420,7 +418,6 @@ func TestCompress(t *testing.T) {
 
 	c2 := &Client{
 		Addr:               ":15352",
-		FlushDelay:         2 * time.Millisecond,
 		DisableCompression: false,
 	}
 	c2.Start()

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -366,9 +366,8 @@ func TestEchoHandler(t *testing.T) {
 
 func TestConcurrentCall(t *testing.T) {
 	s := &Server{
-		Addr:       ":15351",
-		Handler:    func(clientAddr string, request interface{}) interface{} { return request },
-		FlushDelay: time.Millisecond,
+		Addr:    ":15351",
+		Handler: func(clientAddr string, request interface{}) interface{} { return request },
 	}
 	s.Start()
 	defer s.Stop()
@@ -401,9 +400,8 @@ func TestConcurrentCall(t *testing.T) {
 
 func TestCompress(t *testing.T) {
 	s := &Server{
-		Addr:       ":15352",
-		Handler:    func(clientAddr string, request interface{}) interface{} { return request },
-		FlushDelay: time.Millisecond,
+		Addr:    ":15352",
+		Handler: func(clientAddr string, request interface{}) interface{} { return request },
 	}
 	s.Start()
 	defer s.Stop()


### PR DESCRIPTION
- use non-blocking select from single channel when possible
  such select doesn't need heap allocation nor complex logic
- stop timer in client CallTimeout
- detect empty requestsChan and responsesChan instead of timer to flush writers
  with default PendingRequests == PendingResponses == 32768 it is good both for throughput and latency
  (but i'll recomend to decrease default write buffers a bit).