### PR TITLE
fix no delay writer loops

### DIFF
--- a/server.go
+++ b/server.go
@@ -332,35 +332,45 @@ func serverWriter(s *Server, w io.Writer, clientAddr string, responsesChan <-cha
 
 	for {
 		var rpcM *serverMessage
-
 		select {
 		case <-stopChan:
 			return
+		default:
+		}
+
+		select {
 		case rpcM = <-responsesChan:
-			if flushChan == nil {
-				if s.FlushDelay > 0 {
-					flushChan = time.After(s.FlushDelay)
-				} else {
-					flushChan = closedFlushChan
-				}
-			}
-		case <-flushChan:
-			if enabledCompression {
-				if err := ww.Flush(); err != nil {
-					logError("gorpc.Server: [%s]->[%s]. Cannot flush data to compressed stream: [%s]", clientAddr, s.Addr, err)
-					return
-				}
-				if err := zw.Flush(); err != nil {
-					logError("gorpc.Server: [%s]->[%s]. Cannot flush compressed data to wire: [%s]", clientAddr, s.Addr, err)
-					return
-				}
-			}
-			if err := bw.Flush(); err != nil {
-				logError("gorpc.Server: [%s]->[%s]. Cannot flush responses to wire: [%s]", clientAddr, s.Addr, err)
+		default:
+			select {
+			case <-stopChan:
 				return
+			case rpcM = <-responsesChan:
+			case <-flushChan:
+				if enabledCompression {
+					if err := ww.Flush(); err != nil {
+						logError("gorpc.Server: [%s]->[%s]. Cannot flush data to compressed stream: [%s]", clientAddr, s.Addr, err)
+						return
+					}
+					if err := zw.Flush(); err != nil {
+						logError("gorpc.Server: [%s]->[%s]. Cannot flush compressed data to wire: [%s]", clientAddr, s.Addr, err)
+						return
+					}
+				}
+				if err := bw.Flush(); err != nil {
+					logError("gorpc.Server: [%s]->[%s]. Cannot flush responses to wire: [%s]", clientAddr, s.Addr, err)
+					return
+				}
+				flushChan = nil
+				continue
 			}
-			flushChan = nil
-			continue
+		}
+
+		if flushChan == nil {
+			if s.FlushDelay > 0 {
+				flushChan = time.After(s.FlushDelay)
+			} else {
+				flushChan = closedFlushChan
+			}
 		}
 
 		m := wireMessage{


### PR DESCRIPTION
Benching before
- with default flush delay
````
PASS
BenchmarkEchoInt10000Workers-4	  300000	      4327 ns/op
BenchmarkEchoIntNocompress10000Workers-4	  300000	      3911 ns/op
BenchmarkEchoString10000Workers-4	  300000	      4703 ns/op
BenchmarkEchoStringNocompress10000Workers-4	  300000	      4380 ns/op
BenchmarkEchoStruct10000Workers-4	  200000	      6127 ns/op
BenchmarkEchoStructNocompress10000Workers-4	  200000	      5433 ns/op
ok  	_/home/yura/Projects/gorpc	13.575s
````
- with disabled delay
````
PASS
BenchmarkEchoInt10000Workers-4	  200000	      8334 ns/op
BenchmarkEchoIntNocompress10000Workers-4	  300000	      4466 ns/op
BenchmarkEchoString10000Workers-4	  200000	      8551 ns/op
BenchmarkEchoStringNocompress10000Workers-4	  300000	      4785 ns/op
BenchmarkEchoStruct10000Workers-4	  200000	     10674 ns/op
BenchmarkEchoStructNocompress10000Workers-4	  200000	      5675 ns/op
ok  	_/home/yura/Projects/gorpc	15.136s
````

Benching after:
- with default flush delay
````
PASS
BenchmarkEchoInt10000Workers-4	  300000	      4307 ns/op
BenchmarkEchoIntNocompress10000Workers-4	  300000	      3856 ns/op
BenchmarkEchoString10000Workers-4	  300000	      4643 ns/op
BenchmarkEchoStringNocompress10000Workers-4	  300000	      4320 ns/op
BenchmarkEchoStruct10000Workers-4	  200000	      6010 ns/op
BenchmarkEchoStructNocompress10000Workers-4	  200000	      5348 ns/op
ok  	_/home/yura/Projects/gorpc	13.514s
````
- with disabled flush delay
````
PASS
BenchmarkEchoInt10000Workers-4	  300000	      4230 ns/op
BenchmarkEchoIntNocompress10000Workers-4	  300000	      3645 ns/op
BenchmarkEchoString10000Workers-4	  300000	      4341 ns/op
BenchmarkEchoStringNocompress10000Workers-4	  300000	      4029 ns/op
BenchmarkEchoStruct10000Workers-4	  200000	      5884 ns/op
BenchmarkEchoStructNocompress10000Workers-4	  200000	      5240 ns/op
ok  	_/home/yura/Projects/gorpc	13.057s
````

edit: rerun bench with taskset -c 4,5,6,7