### PR TITLE
better make love of wireMesssage and GC

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -5,7 +5,6 @@ import (
 	"compress/flate"
 	"encoding/gob"
 	"io"
-	"sync"
 )
 
 // RegisterType registers the given type to send via rpc.
@@ -22,22 +21,6 @@ func RegisterType(x interface{}) {
 type wireMessage struct {
 	ID   uint64
 	Data interface{}
-}
-
-var wireMessagePool = &sync.Pool{
-	New: func() interface{} {
-		return &wireMessage{}
-	},
-}
-
-func acquireWireMessage() *wireMessage {
-	return wireMessagePool.Get().(*wireMessage)
-}
-
-func releaseWireMessage(wm *wireMessage) {
-	wm.ID = 0
-	wm.Data = nil
-	wireMessagePool.Put(wm)
 }
 
 type messageEncoder struct {


### PR DESCRIPTION
no need to use pool for wireMessage, cause it doesn't leave context of a function.
it is better to allocate it once before loop and reuse.

allocation on a stack didn't work, cause when it were passed to `Decode(interface{})` it were copied to a heap cause of conversion into `interface{}`.

but if allocate in a heap by taking pointer, then only pointer is copied to interface{}