### PR TITLE
Add a conn != nil check

### DIFF
--- a/client.go
+++ b/client.go
@@ -685,7 +685,9 @@ func clientHandleConnection(c *Client, conn io.ReadWriteCloser) {
 		newConn, err := c.OnConnect(c.Addr, conn)
 		if err != nil {
 			c.LogError("gorpc.Client: [%s]. OnConnect error: [%s]", c.Addr, err)
-			conn.Close()
+			if conn != nil {
+				conn.Close()
+			}
 			return
 		}
 		conn = newConn


### PR DESCRIPTION
go version go1.13 linux/amd64
Ubuntu 18.04.3 LTS
----
Т.к. в clientHandler() в рутине происходит conn, err = c.Dial(), то бывают такие случаи...
----

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12ee814]

goroutine 39 [running]:
github.com/valyala/gorpc.clientHandleConnection(0xc0002d0000, 0x0, 0x0)
	/mnt/hdd/home/biter/go/src/github.com/valyala/gorpc/client.go:688 +0x2b4
github.com/valyala/gorpc.clientHandler(0xc0002d0000)
	/mnt/hdd/home/biter/go/src/github.com/valyala/gorpc/client.go:673 +0x4f6
created by github.com/valyala/gorpc.(*Client).Start
	/mnt/hdd/home/biter/go/src/github.com/valyala/gorpc/client.go:157 +0x241
